### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server for managing prompts and templates with project orchestration capabilities.
 
+<a href="https://glama.ai/mcp/servers/i0z4f3pr82">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/i0z4f3pr82/badge" alt="Prompts Server MCP server" />
+</a>
+
 ## Features
 
 - **Prompt Management**: Create, retrieve, update, and delete prompts


### PR DESCRIPTION
This PR adds a badge for the [MCP Prompts Server](https://glama.ai/mcp/servers/i0z4f3pr82) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/i0z4f3pr82">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/i0z4f3pr82/badge" alt="Prompts Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.